### PR TITLE
Enable SCons cache for iterative building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,7 @@ ClientBin/
 *.pfx
 *.publishsettings
 node_modules/
+.cache/
 
 # KDE
 .directory

--- a/SConstruct
+++ b/SConstruct
@@ -303,6 +303,11 @@ if selected_platform in platform_list:
 
 	env.Append(LINKFLAGS = '-Wl,-Map=${TARGET.base}.map')
 
+	scons_cache_path = os.environ.get("SCONS_CACHE")
+	if scons_cache_path is not None:
+    		CacheDir(scons_cache_path)
+    		print("Scons cache enabled... (path: '" + scons_cache_path + "')")
+
 	Export('env')
 
 	#build subdirs, the build order is dependent on link order.


### PR DESCRIPTION
This is a simple addition that copy-pastes 4 lines from the SConstruct of later Godot versions, which tells SCons to use its cache in order to do iterative building.